### PR TITLE
Add .NET backend with PostgreSQL persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .vscode
 frontend/node_modules
 frontend/dist
+frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Aplicação de agenda/calendário em React (Vite) com Tailwind e date-fns.
 
 A API em ASP.NET Core com persistência em PostgreSQL está localizada em `backend/Agendamento.Api`. Ela expõe endpoints REST para eventos e oferece documentação via Swagger.
 
+### Banco de dados (Docker)
+
+Execute um container PostgreSQL com o Docker Compose disponibilizado na raiz do projeto:
+
+```bash
+docker compose up -d postgres
+```
+
 ### Executar o backend
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 Aplicação de agenda/calendário em React (Vite) com Tailwind e date-fns.
 
-## Como executar
+## Backend (.NET)
+
+A API em ASP.NET Core com persistência em PostgreSQL está localizada em `backend/Agendamento.Api`. Ela expõe endpoints REST para eventos e oferece documentação via Swagger.
+
+### Executar o backend
+
+```bash
+cd backend/Agendamento.Api
+# ajustar a string de conexão em appsettings.json se necessário
+(dotnet restore && dotnet run) # requer .NET 8
+```
+
+A API estará disponível em `http://localhost:5000` e o Swagger em `http://localhost:5000/swagger`.
+
+## Frontend
 
 ```bash
 cd frontend

--- a/backend/Agendamento.Api/Agendamento.Api.csproj
+++ b/backend/Agendamento.Api/Agendamento.Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/backend/Agendamento.Api/Controllers/EventsController.cs
+++ b/backend/Agendamento.Api/Controllers/EventsController.cs
@@ -1,0 +1,63 @@
+using Agendamento.Api.Data;
+using Agendamento.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Agendamento.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class EventsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public EventsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Event>>> GetEvents()
+        {
+            return await _context.Events.ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Event>> GetEvent(Guid id)
+        {
+            var ev = await _context.Events.FindAsync(id);
+            if (ev == null) return NotFound();
+            return ev;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Event>> PostEvent(Event ev)
+        {
+            ev.Id = Guid.NewGuid();
+            _context.Events.Add(ev);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetEvent), new { id = ev.Id }, ev);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutEvent(Guid id, Event ev)
+        {
+            if (id != ev.Id) return BadRequest();
+            var exists = await _context.Events.AnyAsync(e => e.Id == id);
+            if (!exists) return NotFound();
+            _context.Entry(ev).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteEvent(Guid id)
+        {
+            var ev = await _context.Events.FindAsync(id);
+            if (ev == null) return NotFound();
+            _context.Events.Remove(ev);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/backend/Agendamento.Api/Data/ApplicationDbContext.cs
+++ b/backend/Agendamento.Api/Data/ApplicationDbContext.cs
@@ -1,0 +1,15 @@
+using Agendamento.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Agendamento.Api.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Event> Events => Set<Event>();
+    }
+}

--- a/backend/Agendamento.Api/Data/SeedData.cs
+++ b/backend/Agendamento.Api/Data/SeedData.cs
@@ -1,0 +1,42 @@
+using Agendamento.Api.Models;
+
+namespace Agendamento.Api.Data
+{
+    public static class SeedData
+    {
+        public static void Initialize(ApplicationDbContext context)
+        {
+            if (context.Events.Any()) return;
+
+            var now = DateTime.UtcNow;
+            var day = new DateTime(now.Year, now.Month, now.Day, 9, 0, 0, DateTimeKind.Utc);
+            context.Events.AddRange(
+                new Event
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Reunião de equipe",
+                    Start = day,
+                    End = day.AddHours(1),
+                    Color = "#3b82f6"
+                },
+                new Event
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Almoço com cliente",
+                    Start = day.AddHours(3),
+                    End = day.AddHours(4),
+                    Color = "#10b981"
+                },
+                new Event
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Call do projeto",
+                    Start = day.AddDays(1),
+                    End = day.AddDays(1).AddHours(1),
+                    Color = "#f59e0b"
+                }
+            );
+            context.SaveChanges();
+        }
+    }
+}

--- a/backend/Agendamento.Api/Models/Event.cs
+++ b/backend/Agendamento.Api/Models/Event.cs
@@ -1,0 +1,14 @@
+namespace Agendamento.Api.Models
+{
+    public class Event
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public string? Location { get; set; }
+        public string? Description { get; set; }
+        public string? Color { get; set; }
+        public int? RemindMinutesBefore { get; set; }
+    }
+}

--- a/backend/Agendamento.Api/Program.cs
+++ b/backend/Agendamento.Api/Program.cs
@@ -1,0 +1,34 @@
+using Agendamento.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+});
+
+var app = builder.Build();
+
+app.UseCors();
+app.UseSwagger();
+app.UseSwaggerUI();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.EnsureCreated();
+    SeedData.Initialize(db);
+}
+
+app.MapControllers();
+
+app.Run();

--- a/backend/Agendamento.Api/Properties/launchSettings.json
+++ b/backend/Agendamento.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Agendamento.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/Agendamento.Api/appsettings.json
+++ b/backend/Agendamento.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=agendamento;Username=postgres;Password=postgres"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/backend/AgendamentoBackend.sln
+++ b/backend/AgendamentoBackend.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Agendamento.Api", "Agendamento.Api\\Agendamento.Api.csproj", "{534177F5-5F68-48AB-ACC2-3B231073227B}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {534177F5-5F68-48AB-ACC2-3B231073227B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {534177F5-5F68-48AB-ACC2-3B231073227B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {534177F5-5F68-48AB-ACC2-3B231073227B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {534177F5-5F68-48AB-ACC2-3B231073227B}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: agendamento
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,35 +5,7 @@ import EventForm from './components/EventForm';
 import { Event } from './types';
 import { add, fmt, parse } from './lib/date';
 
-const STORAGE_KEY = 'agenda.events.v1';
-
-const sample = (): Event[] => {
-  const now = new Date();
-  const day = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 9, 0);
-  return [
-    {
-      id: crypto.randomUUID(),
-      title: 'Reunião de equipe',
-      start: day.toISOString(),
-      end: new Date(day.getTime() + 60 * 60 * 1000).toISOString(),
-      color: '#3b82f6',
-    },
-    {
-      id: crypto.randomUUID(),
-      title: 'Almoço com cliente',
-      start: new Date(day.getTime() + 3 * 60 * 60 * 1000).toISOString(),
-      end: new Date(day.getTime() + 4 * 60 * 60 * 1000).toISOString(),
-      color: '#10b981',
-    },
-    {
-      id: crypto.randomUUID(),
-      title: 'Call do projeto',
-      start: new Date(day.getTime() + 24 * 60 * 60 * 1000).toISOString(),
-      end: new Date(day.getTime() + 25 * 60 * 60 * 1000).toISOString(),
-      color: '#f59e0b',
-    },
-  ];
-};
+const API_URL = 'http://localhost:5000/api/events';
 
 function App() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -44,19 +16,11 @@ function App() {
   const [selected, setSelected] = useState<Event | null>(null);
 
   useEffect(() => {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) setEvents(JSON.parse(raw));
-    else {
-      const seed = sample();
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(seed));
-      setEvents(seed);
-    }
+    fetch(API_URL)
+      .then(r => r.json())
+      .then(setEvents)
+      .catch(() => setEvents([]));
   }, []);
-
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
-  }, [events]);
-
 
   useEffect(() => {
     const timers = events
@@ -86,14 +50,32 @@ function App() {
     [events, search]
   );
 
-  const handleSave = (ev: Event) => {
+  const saveRemote = async (ev: Event) => {
+    const exists = events.find(e => e.id === ev.id);
+    const method = exists ? 'PUT' : 'POST';
+    const url = exists ? `${API_URL}/${ev.id}` : API_URL;
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ev),
+    });
+    if (method === 'POST') {
+      const created = await res.json();
+      return created as Event;
+    }
+    return ev;
+  };
+
+  const handleSave = async (ev: Event) => {
+    const saved = await saveRemote(ev);
     setEvents((prev) => {
-      const exists = prev.find((p) => p.id === ev.id);
-      return exists ? prev.map((p) => (p.id === ev.id ? ev : p)) : [...prev, ev];
+      const exists = prev.find((p) => p.id === saved.id);
+      return exists ? prev.map((p) => (p.id === saved.id ? saved : p)) : [...prev, saved];
     });
   };
 
-  const handleDelete = (id: string) => {
+  const handleDelete = async (id: string) => {
+    await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
     setEvents((prev) => prev.filter((e) => e.id !== id));
   };
 


### PR DESCRIPTION
## Summary
- create ASP.NET Core API with PostgreSQL persistence, Swagger, and sample seeding
- integrate frontend with backend API for event CRUD
- document backend setup in README and ignore package-lock.json

## Testing
- `npm test --prefix frontend`
- `dotnet build backend/Agendamento.Api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975331bb708330bb78dc7eccd344a2